### PR TITLE
Render existing panel nodes instead of cloning their HTML

### DIFF
--- a/src/lib/Panel.svelte
+++ b/src/lib/Panel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { children } from './actions';
 	import type { PanelRef, PanelDefinition } from './types';
 
 	export let props: PanelDefinition;
@@ -13,11 +14,12 @@
 	});
 </script>
 
-<div class={`st-panel ${align || ''} ${panelClass || ''}`} bind:this={panelRef}>
-  {#each nodes as node}
-    {@html node.outerHTML}
-  {/each}
-</div>
+<div
+	class={`st-panel ${align || ''} ${panelClass || ''}`}
+	bind:this={panelRef}
+	use:children={nodes}
+/>
+
 
 <style lang="scss">
   $breakpoint: 61.25rem;

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,0 +1,11 @@
+import type { Action } from 'svelte/action';
+
+export const children: Action<Element, Node[]> = (el, children) => {
+	children.forEach((node) => el.appendChild(node));
+
+	return {
+		destroy() {
+			children.forEach((node) => el.removeChild(node));
+		}
+	};
+};


### PR DESCRIPTION
We've run into an issue while building a scrollyteller where we need to maintain a reference to some panel content nodes (lazy-loading Odyssey image embeds).

The current implementation of the svelte scrollyteller `Panel` component effectively clones the original nodes (with `outerHTML`) and renders a static copy of the nodes.

This differs from the original React scrollyteller, which does use the original nodes that are plucked from the page.

This PR adds a `children` svelte action, designed to be exected as a [`use:` directive](https://learn.svelte.dev/tutorial/actions). It takes the nodes as its parameter, and simply mounts each of them to the panel, and un-mounts them if the component is destroyed.

This effectively allows us to properly mount/unmount panel nodes to/from panels without the need to clone their HTML.