### PR TITLE
Start and End block margins fix

### DIFF
--- a/examples/aunty/src/components/CustomPanel.svelte
+++ b/examples/aunty/src/components/CustomPanel.svelte
@@ -41,11 +41,11 @@
     position: relative;
     z-index: 1;
 
-    &.first {
+    &:first-of-type {
       margin-top: 100vh;
     }
 
-    &.last {
+    &:last-of-type {
       margin-bottom: 100vh;
     }
 


### PR DESCRIPTION
.first and .last classes don't seem to be applied. This is just a quick fix.