### PR TITLE
Feature/svelte 4 pointer events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"svelte": "^3.0.0"
+				"svelte": "^4.2.8"
 			}
 		},
 		"node_modules/@abcnews/alternating-case-to-object": {
@@ -47,6 +47,19 @@
 			"integrity": "sha512-jE9edpjfOrbkBOpPWu+gI8WU9flZRDCQ/xcnF1LpornwmeYghyiYeE4zFKEkgjUPCp6sdbvLSi0DOlW0C6f6mg==",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@ampproject/remapping": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -602,11 +615,33 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
 			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"peer": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -614,14 +649,12 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.15",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-			"dev": true
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.19",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
 			"integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -872,6 +905,12 @@
 			"integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==",
 			"dev": true
 		},
+		"node_modules/@types/estree": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"peer": true
+		},
 		"node_modules/@types/http-cache-semantics": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -912,6 +951,18 @@
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+			"peer": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/aggregate-error": {
@@ -1033,6 +1084,24 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
+		},
+		"node_modules/aria-query": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+			"peer": true,
+			"dependencies": {
+				"dequal": "^2.0.3"
+			}
+		},
+		"node_modules/axobject-query": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
+			"integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
+			"peer": true,
+			"dependencies": {
+				"dequal": "^2.0.3"
+			}
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -1608,6 +1677,19 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/code-red": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
+			"integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.15",
+				"@types/estree": "^1.0.1",
+				"acorn": "^8.10.0",
+				"estree-walker": "^3.0.3",
+				"periscopic": "^3.1.0"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1855,6 +1937,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/css-tree": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+			"peer": true,
+			"dependencies": {
+				"mdn-data": "2.0.30",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
 		"node_modules/date-fns": {
 			"version": "1.30.1",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
@@ -2016,6 +2111,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/detect-indent": {
@@ -2192,6 +2296,15 @@
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
 			"integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
 			"dev": true
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
 		},
 		"node_modules/execa": {
 			"version": "7.2.0",
@@ -3350,6 +3463,15 @@
 			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
 			"dev": true
 		},
+		"node_modules/is-reference": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
+			"integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "*"
+			}
+		},
 		"node_modules/is-scoped": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-3.0.0.tgz",
@@ -3971,6 +4093,12 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
+		"node_modules/locate-character": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+			"peer": true
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4173,16 +4301,21 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.3",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
-			"integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
-			"dev": true,
+			"version": "0.30.5",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
 			},
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.0.30",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+			"peer": true
 		},
 		"node_modules/meow": {
 			"version": "12.1.1",
@@ -5128,6 +5261,17 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/periscopic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^3.0.0",
+				"is-reference": "^3.0.0"
 			}
 		},
 		"node_modules/picocolors": {
@@ -6097,7 +6241,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6243,12 +6386,27 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "3.59.2",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
-			"integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.8.tgz",
+			"integrity": "sha512-hU6dh1MPl8gh6klQZwK/n73GiAHiR95IkFsesLPbMeEZi36ydaXL/ZAb4g9sayT0MXzpxyZjR28yderJHxcmYA==",
 			"peer": true,
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.1",
+				"@jridgewell/sourcemap-codec": "^1.4.15",
+				"@jridgewell/trace-mapping": "^0.3.18",
+				"acorn": "^8.9.0",
+				"aria-query": "^5.3.0",
+				"axobject-query": "^3.2.1",
+				"code-red": "^1.0.3",
+				"css-tree": "^2.3.1",
+				"estree-walker": "^3.0.3",
+				"is-reference": "^3.0.1",
+				"locate-character": "^3.0.0",
+				"magic-string": "^0.30.4",
+				"periscopic": "^3.1.0"
+			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">=16"
 			}
 		},
 		"node_modules/svelte-check": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"vite": "^4.4.2"
 	},
 	"peerDependencies": {
-		"svelte": "^3.0.0"
+		"svelte": "^4.2.8"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/src/TestExample/Worm/Worm.svelte
+++ b/src/TestExample/Worm/Worm.svelte
@@ -1,30 +1,57 @@
 <script>
-  import worm from './worm.svg';
+	import worm from './worm.svg';
+
+	let animating = false;
+	function onClick() {
+		animating = !animating;
+	}
 </script>
 
 <div class="wrapper">
-  <div class="text"><slot /></div>
-  <img src={worm} alt="" />
+	<div class="text"><slot /></div>
+	<button on:click={onClick}>
+		<img src={worm} alt="" class={animating && 'animating'} />
+	</button>
 </div>
 
 <style lang="scss">
-  img {
-    width: 240px;
-    height: auto;
-  }
+	button {
+		background: none;
+		border: none;
+	}
+	img {
+		width: 240px;
+		height: auto;
+		transition: all 1s;
+	}
+	img.animating {
+		animation: pulse 2s infinite;
+	}
 
-  .wrapper {
-    position: relative;
-    display: flex;
-    margin: auto;
-  }
+	.wrapper {
+		position: relative;
+		display: flex;
+		margin: auto;
+	}
 
-  .text {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    font-size: xx-large;
-    font-weight: 900;
-  }
+	.text {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		font-size: xx-large;
+		font-weight: 900;
+	}
+
+	@keyframes pulse {
+		from {
+			scale: 1;
+		}
+		50% {
+			scale: 1.1;
+		}
+		to {
+			scale: 1;
+		}
+	}
 </style>

--- a/src/lib/Panel.svelte
+++ b/src/lib/Panel.svelte
@@ -40,6 +40,8 @@
 		position: relative;
 		z-index: 1;
 
+		pointer-events: none;
+
 		&.first {
 			margin-top: 100vh;
 		}
@@ -71,7 +73,12 @@
 		}
 
 		:global(> *) {
-			font-family: ABCSerif, Book Antiqua, Palatino Linotype, Palatino, serif;
+			font-family:
+				ABCSerif,
+				Book Antiqua,
+				Palatino Linotype,
+				Palatino,
+				serif;
 			font-size: 1.375rem;
 			line-height: 1.666666667;
 			color: var(--color-panel-text, #fefefe);
@@ -84,6 +91,8 @@
 			margin-right: auto !important;
 
 			width: 66.666667%;
+
+			pointer-events: all;
 
 			&:last-child {
 				margin-bottom: 0;

--- a/src/lib/Scrollyteller.svelte
+++ b/src/lib/Scrollyteller.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import Panel from './Panel.svelte';
-	import { onMount } from 'svelte';
 	import type { ComponentType } from 'svelte';
+	import { onMount } from 'svelte';
+	import Panel from './Panel.svelte';
 	import type { IntersectionEntries, PanelDefinition, PanelRef } from './types.js';
 
 	enum ScrollPositions {
@@ -122,5 +122,6 @@
 		min-height: 100dvh;
 		display: flex;
 		flex-direction: column;
+		pointer-events: none;
 	}
 </style>


### PR DESCRIPTION
1. Upgrade Svelte to @4: This will be a breaking change, but brings us up to date with the latest @abcnews/aunty.
2. Allow interacting with interactives underneath the scrolling panels. I need this for out TikTok interactive + possibly the undersea cables interactive. I asked our team last week and we don't expect this will break anything, but I've tagged everyone to have a look.

The pointer events still work on panels, so people can interact with the text as normal. I've added some interaction to the worm in the demo so we can verify it works.