### PR TITLE
Feature: unload offscreen graphics & defer marker updates while scrolling faster than threshold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "2.0.0",
 			"dependencies": {
 				"@abcnews/alternating-case-to-object": "^3.0.2",
-				"@abcnews/mount-utils": "^3.0.0"
+				"@abcnews/mount-utils": "^3.0.0",
+				"debounce-throttle": "^1.0.4"
 			},
 			"devDependencies": {
 				"@sveltejs/kit": "^1.22.1",
@@ -644,6 +645,18 @@
 			"peer": true,
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+			"integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
@@ -1337,6 +1350,14 @@
 				"node": "*"
 			}
 		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/builtins": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
@@ -1955,6 +1976,11 @@
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
 			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
 			"dev": true
+		},
+		"node_modules/debounce-throttle": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/debounce-throttle/-/debounce-throttle-1.0.4.tgz",
+			"integrity": "sha512-dg3ImASYct9Kymx8Wm+uC9luq2BkbTrULrS/CzAVTYvVJibhYgXznKVytlqhMC8plSl6U5Fxy5bfWu+JhYI7ww=="
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -6237,12 +6263,35 @@
 				"sorcery": "bin/sorcery"
 			}
 		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"node_modules/spawn-command": {
@@ -6582,6 +6631,34 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/terser": {
+			"version": "5.28.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.28.1.tgz",
+			"integrity": "sha512-wM+bZp54v/E9eRRGXb5ZFDvinrJIOaTapx3WUokyVGZu5ucVCK55zEgGd5Dl2fSr3jUo5sDiERErUWLY6QPFyA==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"bin": {
+				"terser": "bin/terser"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/terser/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/through": {
 			"version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
 	},
 	"dependencies": {
 		"@abcnews/alternating-case-to-object": "^3.0.2",
-		"@abcnews/mount-utils": "^3.0.0"
+		"@abcnews/mount-utils": "^3.0.0",
+		"debounce-throttle": "^1.0.4"
 	},
 	"type": "module",
 	"main": "./dist/index.js",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -139,3 +139,40 @@ const loadPanels = (nodes: Element[], initialConfig, name: string): PanelDefinit
 
 	return panels;
 };
+
+/**
+ * An onScroll handler with throttling and scroll speed limiting.
+ *
+ * This is used because flinging the page up in Safari was creating too many
+ * WebGL contexts and crashing the tab.
+ *
+ * @param fn - Function to call back when on scroll.
+ * @param options
+ * @param options.interval - interval to debounce scroll check.
+ */
+export const getScrollSpeed = (callback: (speed: number) => void) => {
+	const getScrollTop = () => document.documentElement.scrollTop;
+	let lastOffset = getScrollTop();
+	let lastDate = Date.now();
+
+	const onScroll = () => {
+		const delayInMs = Date.now() - lastDate;
+		const offset = getScrollTop() - lastOffset;
+		const speedInpxPerMs = offset / delayInMs;
+		const scrollSpeed = Math.abs(speedInpxPerMs);
+
+		lastDate = Date.now();
+		lastOffset = getScrollTop();
+
+		callback(scrollSpeed);
+	};
+	window.addEventListener("scroll", onScroll, { passive: true });
+
+	const onEndScroll = () => callback(0);
+	window.addEventListener("scrollend", onEndScroll, { passive: true });
+
+	return () => {
+		window.removeEventListener('scroll', onScroll);
+		window.removeEventListener('scrollend', onEndScroll);
+	}
+}


### PR DESCRIPTION
These optimisations are hard(/impossible?) to implement in the interactives that consume svelte-scrollyteller. Adding it here makes it easier to reuse and it seems the right place for it.

### unload offscreen graphics
When a scrollyteller scrolls offscreen, this change unmounts the component and removes the graphic from the DOM.

The intention is to save memory when not in use. This is mostly useful when using multiple scrollytellers in the page, or where the scrollyteller is only used for part of the article.

The trade-off is you may need to use `<link rel="preload"` for resources that don't appear in the page by default.

### defer marker updates while scrolling faster than threshold
Safari on iOS/iPadOS has a habit of crashing when dealing with lots of layers/WebGL/memory use. 

Flinging the page quickly on our interactive would trigger lots of consecutive markers, which would trigger a bunch of renders, and sometimes crash Safari.

This change defers marker operations until the page settles down past a certain threshold.

### Opt-in
These two features are opt-in so we can see how they work before deciding if it's worth rolling them out as a default.

Do this with: `<Scrollyteller discardSlot={true}`