### PR TITLE
feature: export scrollyteller as a web component for use in other frameworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .env
 .env.*
 !.env.example
+/dist-wc

--- a/README.WebComponent.md
+++ b/README.WebComponent.md
@@ -1,0 +1,97 @@
+# Svelte Scrollyteller Web Component
+
+While the Svelte Scrollyteller is provided for use in Svelte projects, a web component build is provided for use in non-svelte projects like React or native JS.
+
+This documentation assumes you know how to bootstrap a Svelte Scrollyteller in a Svelte project (see [README.md](README.md));
+
+## Low level usage
+
+Import the web component into your project with:
+
+```js
+/** @ts-ignore import self-executes so abcnews-scrollyteller available as an element */
+import { Scrollyteller, loadScrollyteller} from '@abcnews/svelte-scrollyteller/wc';
+```
+
+Then use the component like so:
+
+```html
+<abcnews-scrollyteller
+    className="someClass"
+    panelClassName="panelClass"
+    firstPanelClassName="firstPanelClass"
+    lastPanelClassName="lastPanelClass"
+    theme="light" />
+```
+
+Since we can't pass complex types to web components, we must set panels manually with Javascript:
+
+```js
+const current = document.querySelector('abcnews-scrollyteller');
+
+// In Odyssey these would be generated with `loadScrollyteller()`
+current.panels = [
+    {
+        data: {customData: 'red'},
+        nodes: Object.assign(document.createElement('p'), {innerText: 'Hello world'}),
+    },
+    {
+        data: {customData: 'green'},
+        nodes: Object.assign(document.createElement('p'), {innerText: 'This is the second panel'}),
+    },
+];
+```
+
+For backward compatibility the web component doesn't use shadow dom, so your app can override styles. This means slots don't work as expected, so you must manually insert child nodes into the `graphicRootEl`.
+
+The component emits a `load` and `marker` event, so you can use both to initialise and update child nodes:
+
+```js
+current.addEventListener('load', () => current.graphicRootEl.appendChild(myGraphics));
+current.addEventListener('marker', e => myGraphics.style.background = e.detail.customData);
+```
+
+Custom panels are not supported in the web component.
+
+## Usage in React
+
+You can use the following boilerplate component to handle this for you. Continue bootstrapping panels with `loadScrollyteller` as you would in a Svelte project (see [README.md](README.md)), then use this wrapper component to interface with the Web Component:
+
+```tsx
+/** @ts-ignore import self-executes so abcnews-scrollyteller is available as an element */
+import Scrollyteller from '@abcnews/svelte-scrollyteller/wc';
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+function ScrollytellerPortalChild({ domNode, children }) {
+  if (!domNode) {
+    return null;
+  }
+  return createPortal(children, domNode);
+}
+
+export default function ScrollytellerWebComponent({ children, panels, styles, onMarker }) {
+  const scrollyEl: typeof Scrollyteller.element = useRef();
+  const [scrollyPortal, setScrollyPortal] = useState();
+
+  useEffect(() => {
+    const { current } = scrollyEl;
+    if (!current) return;
+    current.panels = panels;
+    current.addEventListener('load', () => setScrollyPortal(current.graphicRootEl));
+    current.addEventListener('marker', e => onMarker(e.detail));
+  }, [scrollyEl]);
+
+  return (<>
+    <ScrollytellerPortalChild domNode={scrollyPortal}>
+      {children}
+    </ScrollytellerPortalChild>
+    <abcnews-scrollyteller
+      ref={scrollyEl}
+      className={styles.scrollyteller}
+      panelClassName={styles.panel}
+      firstPanelClassName={styles.firstPanel}
+      lastPanelClassName={styles.lastPanel} />
+  </>);
+}
+```

--- a/README.WebComponent.md
+++ b/README.WebComponent.md
@@ -1,12 +1,12 @@
 # Svelte Scrollyteller Web Component
 
-While the Svelte Scrollyteller is provided for use in Svelte projects, a web component build is provided for use in non-svelte projects like React or native JS.
+While the Svelte Scrollyteller is provided for use in Svelte projects, a Web Component build is provided for use in non-svelte projects like React or native JS.
 
 This documentation assumes you know how to bootstrap a Svelte Scrollyteller in a Svelte project (see [README.md](README.md));
 
 ## Low level usage
 
-Import the web component into your project with:
+Import the Web Component into your project with:
 
 ```js
 /** @ts-ignore import self-executes so abcnews-scrollyteller available as an element */
@@ -24,7 +24,7 @@ Then use the component like so:
     theme="light" />
 ```
 
-Since we can't pass complex types to web components, we must set panels manually with Javascript:
+Since we can't pass complex types to Web Components, we must set panels manually with Javascript:
 
 ```js
 const current = document.querySelector('abcnews-scrollyteller');
@@ -42,7 +42,7 @@ current.panels = [
 ];
 ```
 
-For backward compatibility the web component doesn't use shadow dom, so your app can override styles. This means slots don't work as expected, so you must manually insert child nodes into the `graphicRootEl`.
+For backward compatibility the Web Component doesn't use shadow dom, so your app can override styles. This means slots don't work as expected, so you must manually insert child nodes into the `graphicRootEl`.
 
 The component emits a `load` and `marker` event, so you can use both to initialise and update child nodes:
 
@@ -51,7 +51,7 @@ current.addEventListener('load', () => current.graphicRootEl.appendChild(myGraph
 current.addEventListener('marker', e => myGraphics.style.background = e.detail.customData);
 ```
 
-Custom panels are not supported in the web component.
+Custom panels are not supported in the Web Component.
 
 ## Usage in React
 

--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ new App({
 
 ## Usage with other non-Svelte frameworks
 
-The scrollyteller is available as a web component for use in other frameworks. See [README.WebComponent.md](README.WebComponent.md) for more info.
+The scrollyteller is available as a Web Component for use in other frameworks. See [README.WebComponent.md](README.WebComponent.md) for more info.
 
 ## Development
 
 The Svelte components are [packaged using SvelteKit svelte-package](https://kit.svelte.dev/docs/packaging).
 
-The web components are built separately using Vite with the `vite-webcomponents.config.js` config.
+The Web Component is built separately using Vite with the `vite-webcomponents.config.js` config.
 
 ### Get started
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,15 @@ new App({
 });
 ```
 
+## Usage with other non-Svelte frameworks
+
+The scrollyteller is available as a web component for use in other frameworks. See [README.WebComponent.md](README.WebComponent.md) for more info.
+
 ## Development
 
-This is [packaged using SvelteKit](https://kit.svelte.dev/docs/packaging).
+The Svelte components are [packaged using SvelteKit svelte-package](https://kit.svelte.dev/docs/packaging).
+
+The web components are built separately using Vite with the `vite-webcomponents.config.js` config.
 
 ### Get started
 

--- a/package.json
+++ b/package.json
@@ -2,11 +2,9 @@
 	"name": "@abcnews/svelte-scrollyteller",
 	"version": "2.1.0",
 	"scripts": {
-		"dev": "concurrently \"vite dev\" \"svelte-package --watch\"",
-		"build": "vite build",
-		"preview": "vite preview",
-		"package": "svelte-package",
-		"test": "",
+		"dev": "concurrently \"vite dev\" \"svelte-package --watch\" 'vite build --watch --config vite.webcomponents.config.js'",
+		"package": "svelte-package && npm run package-webcomponent",
+		"package-webcomponent": "npx vite build --config vite.webcomponents.config.js",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. .",
@@ -53,6 +51,9 @@
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js",
 			"default": "./dist/index.js"
+		},
+		"./wc": {
+			"default": "./dist-wc/svelte-scrollyteller.js"
 		}
 	},
 	"files": [

--- a/src/lib/Scrollyteller.wc.svelte
+++ b/src/lib/Scrollyteller.wc.svelte
@@ -1,0 +1,34 @@
+<svelte:options
+	customElement={{
+		tag: 'abcnews-scrollyteller',
+		shadow: 'none'
+	}}
+	accessors={true}
+/>
+
+<script>
+	/**
+	 * @file
+	 * A Web Component export of the Svelte Scrollyteller.
+	 *
+	 * You should only use this in non-Svelte projects, such as older React
+	 * codebases that can't be updated.
+	 */
+	import Scrollyteller from './Scrollyteller.svelte';
+	import { createEventDispatcher } from 'svelte';
+
+	const dispatch = createEventDispatcher();
+	export let panels = [];
+	export let graphicRootEl;
+	$: {
+		if (graphicRootEl) {
+			dispatch('load', graphicRootEl);
+		}
+	}
+</script>
+
+{#if panels.length}
+	<Scrollyteller {panels} onMarker={(marker) => dispatch('marker', marker)} {...$$restProps}>
+		<div bind:this={graphicRootEl}></div>
+	</Scrollyteller>
+{/if}

--- a/src/lib/index.wc.ts
+++ b/src/lib/index.wc.ts
@@ -1,6 +1,6 @@
 /**
  * @file
- * Web component entrypoint. Everything in this entrypoint gets compiled down
+ * Web Component entrypoint. Everything in this entrypoint gets compiled down
  * to plain Javascript so it can be consumed by non-Svelte projects.
  */
 import Scrollyteller from './Scrollyteller.wc.svelte';

--- a/src/lib/index.wc.ts
+++ b/src/lib/index.wc.ts
@@ -1,0 +1,9 @@
+/**
+ * @file
+ * Web component entrypoint. Everything in this entrypoint gets compiled down
+ * to plain Javascript so it can be consumed by non-Svelte projects.
+ */
+import Scrollyteller from './Scrollyteller.wc.svelte';
+export { loadScrollyteller } from './utils.js';
+
+export default Scrollyteller;

--- a/vite.webcomponents.config.js
+++ b/vite.webcomponents.config.js
@@ -1,5 +1,4 @@
 import { defineConfig } from 'vite';
-import dts from "vite-plugin-dts";
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import path from 'path';
 

--- a/vite.webcomponents.config.js
+++ b/vite.webcomponents.config.js
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite';
+import dts from "vite-plugin-dts";
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import path from 'path';
+
+export default defineConfig({
+    plugins: [svelte({
+        compilerOptions: {
+            customElement: true,
+        },
+    }),],
+    build: {
+        outDir: path.resolve(__dirname, './dist-wc'),
+        emptyOutDir: true,
+        minify: false,
+        lib: {
+            entry: path.resolve(__dirname, './src/lib/index.wc.ts'),
+            name: 'Scrollyteller',
+            formats: ['es']
+        },
+    }
+});


### PR DESCRIPTION
I've successfully got this running in the [React US election repo](https://master-news-web.news-web-developer.presentation-layer.abc-prod.net.au/news/2020-11-02/us-election-trump-biden-states-polling/104146256?terminusBaseURL=https://api-preview.private.terminus.abc-prod.net.au/api/v2&future=true).  🙌 