### PR TITLE
bug: wrong marker fired when intersectingPanels not cleaned up

### DIFF
--- a/src/lib/Scrollyteller/PanelObserver.svelte
+++ b/src/lib/Scrollyteller/PanelObserver.svelte
@@ -73,39 +73,35 @@
 	 */
 	let intersectingPanels = [];
 
-	function doPanelObserver(steps, _observerOptions) {
-		intersectingPanels = [];
-		panelObserver?.disconnect();
-		panelObserver = new IntersectionObserver((entries: IntersectionEntries[]) => {
-			entries.forEach((entry) => {
-				if (entry.isIntersecting) {
-					intersectingPanels.push(entry);
-				} else {
-					const itemToRemove = intersectingPanels.findIndex(
-						(panel) => panel.target === entry.target
-					);
-					if (itemToRemove === -1) return;
-					intersectingPanels.splice(itemToRemove, 1);
-				}
-
-				// The current panel is the most recently intersected panel.
-				// If the most recent panel scrolls out, this falls back to
-				// any earlier panels that are still intersecting.
-				const newPanel = intersectingPanels[intersectingPanels.length - 1];
-				if (newPanel) {
-					marker = newPanel.target.scrollyData;
-					$currentPanel = steps.findIndex((step) => step === newPanel.target);
-				}
-			});
-		}, _observerOptions);
-		steps.forEach((step) => {
-			panelObserver.observe(step);
-		});
-	}
-
 	$: {
 		if ($vizDims.status === 'ready') {
-			doPanelObserver($steps, _observerOptions);
+			intersectingPanels = [];
+			panelObserver?.disconnect();
+			panelObserver = new IntersectionObserver((entries: IntersectionEntries[]) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						intersectingPanels.push(entry);
+					} else {
+						const itemToRemove = intersectingPanels.findIndex(
+							(panel) => panel.target === entry.target
+						);
+						if (itemToRemove === -1) return;
+						intersectingPanels.splice(itemToRemove, 1);
+					}
+
+					// The current panel is the most recently intersected panel.
+					// If the most recent panel scrolls out, this falls back to
+					// any earlier panels that are still intersecting.
+					const newPanel = intersectingPanels[intersectingPanels.length - 1];
+					if (newPanel) {
+						marker = newPanel.target.scrollyData;
+						$currentPanel = $steps.findIndex((step) => step === newPanel.target);
+					}
+				});
+			}, _observerOptions);
+			$steps.forEach((step) => {
+				panelObserver.observe(step);
+			});
 		} else {
 			panelObserver?.disconnect();
 		}

--- a/src/lib/Scrollyteller/PanelObserver.svelte
+++ b/src/lib/Scrollyteller/PanelObserver.svelte
@@ -56,13 +56,11 @@
 	let _observerOptions: IntersectionObserverInit = observerOptions;
 	$: {
 		if (observerOptions) {
-			console.log('observer options found');
 			_observerOptions = observerOptions;
 		} else {
 			_observerOptions = {
 				rootMargin: `-${rootMargin}px 0px -${rootMargin}px 0px`
 			};
-			console.log('setting', { _observerOptions });
 		}
 	}
 
@@ -75,7 +73,7 @@
 	 */
 	let intersectingPanels = [];
 
-	function doPanelObserver(steps) {
+	function doPanelObserver(steps, _observerOptions) {
 		intersectingPanels = [];
 		panelObserver?.disconnect();
 		panelObserver = new IntersectionObserver((entries: IntersectionEntries[]) => {
@@ -107,7 +105,7 @@
 
 	$: {
 		if ($vizDims.status === 'ready') {
-			doPanelObserver($steps);
+			doPanelObserver($steps, _observerOptions);
 		} else {
 			panelObserver?.disconnect();
 		}


### PR DESCRIPTION
On the mobile viewport, sometimes the wrong marker was loaded,.

This is because:
1. I'm reloading the observer when the viewport/graphic size changes
2. I'm keeping track of the previously matched panels in `intersectingPanels`. It makes the interface more predictable when you scroll back up, I can explain more separately if you like.
3. Because I'm reloading the observer, panels in the `intersectingPanels` array don't get cleared. Thus sometimes this logic matched the wrong panels after the observer reloaded.

~~I've moved this into a separate function because I only need this to be rerun if the steps/observer options change. Does this make sense?~~

Ok I undid that last refactor ☝️  because it's unrelated to the bugfix, and I don't want to potentially introduce new bugs in prod right now