### PR TITLE
bug: scrollyteller thrashing on load/race condition reading getBoundingClientRect

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 ## Development
 
-Working on scelkte-scrollyteller can be done one of two ways:
+Working on svelte-scrollyteller can be done one of two ways:
 
-1. In this repo, using the `npm start` command, which will spin up a local server and give you a tool with various scrollyteller parameters.
-2. By `npm link`ing into your project. This is less straightforward, and is covered below:
+1. In this repo, using the `npm start` command to spin up a local server and give you a tool with various scrollyteller parameters you can tweak
+2. Or by `npm link`ing into your project. This is less straightforward, and is covered below:
 
 ### `npm link` into your Aunty project
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+## Development
+
+Working on scelkte-scrollyteller can be done one of two ways:
+
+1. In this repo, using the `npm start` command, which will spin up a local server and give you a tool with various scrollyteller parameters.
+2. By `npm link`ing into your project. This is less straightforward, and is covered below:
+
+### `npm link` into your Aunty project
+
+1. run `npm link` in the svelte-scrollyteller repo
+2. from your Aunty repo run `npm link @abcnews/svelte-scrollyteller`
+3. Configure Aunty to transpile the linked repo by adding the _fully resolved path_ to your working directory. E.g. `"includedDependencies": ["/Users/ashk/Web/svelte-scrollyteller"]
+
+The last step is important because Webpack resolves symlinks itself, so adding the `@abcnews/svelte-scrollyteller` package name to `includedDependencies` won't work with linked packages.

--- a/src/lib/Scrollyteller.svelte
+++ b/src/lib/Scrollyteller.svelte
@@ -1,5 +1,3 @@
-<svelte:options runes={false} />
-
 <script lang="ts">
 	import type { ComponentType } from 'svelte';
 	import { onMount, setContext } from 'svelte';

--- a/src/lib/Scrollyteller.svelte
+++ b/src/lib/Scrollyteller.svelte
@@ -1,10 +1,11 @@
+<svelte:options runes={false} />
+
 <script lang="ts">
 	import type { ComponentType } from 'svelte';
 	import { onMount, setContext } from 'svelte';
 	import type { PanelDefinition, Style } from './types.js';
-	import { ScrollPositions } from './types.js';
 	import { createEventDispatcher } from 'svelte';
-	import { getScrollingPos, getScrollSpeed } from './Scrollyteller/Scrollyteller.util';
+	import { getScrollSpeed } from './Scrollyteller/Scrollyteller.util';
 	import OnProgressHandler from './Scrollyteller/OnProgressHandler.svelte';
 	import PanelObserver from './Scrollyteller/PanelObserver.svelte';
 	import ScreenDimsStoreUpdater from './Scrollyteller/ScreenDimsStoreUpdater.svelte';
@@ -55,7 +56,7 @@
 	export let customPanel: ComponentType | null = null;
 	export let panels: PanelDefinition[];
 	export let onProgress = () => {};
-	export let onMarker = () => {};
+	export let onMarker = (marker) => {};
 	export let onLoad = () => {};
 	export let observerOptions: IntersectionObserverInit = undefined;
 	/**
@@ -101,7 +102,6 @@
 
 	let scrollytellerRef: HTMLElement | undefined;
 	let marker: any;
-	let scrollingPos: ScrollPositions;
 	let isInViewport = false;
 	let scrollSpeed = 0;
 	let deferUntilScrollSettlesActions = [];
@@ -130,10 +130,6 @@
 	};
 
 	onMount(() => {
-		scrollingPos = getScrollingPos(scrollytellerRef);
-		if (scrollingPos === ScrollPositions.ABOVE) marker = panels[0].data;
-		if (scrollingPos === ScrollPositions.BELOW) marker = panels[panels.length - 1].data;
-
 		if (discardSlot) {
 			scrollytellerObserver.observe(scrollytellerRef);
 		}
@@ -169,7 +165,7 @@
 	{/if}
 </svelte:head>
 
-<div class="scrollyteller-wrapper">
+<div class="scrollyteller-wrapper" style:opacity={$vizDimsStore.status === 'ready' ? 1 : 0}>
 	{#if !_layout.resizeInteractive}
 		<Viz layout={_layout} {isInViewport} {discardSlot} {onLoad}><slot /></Viz>
 	{/if}
@@ -193,6 +189,7 @@
 	@import './breakpoints.scss';
 	.scrollyteller-wrapper {
 		position: relative;
+		transition: opacity 0.25s;
 	}
 	.scrollyteller {
 		position: relative;

--- a/src/lib/Scrollyteller/Scrollyteller.util.ts
+++ b/src/lib/Scrollyteller/Scrollyteller.util.ts
@@ -1,16 +1,3 @@
-import { ScrollPositions } from '../types.js';
-
-export const getScrollingPos = (scrollytellerRef) => {
-	const boundingRect = scrollytellerRef.getBoundingClientRect();
-	if (boundingRect.bottom - window.innerHeight < 0) {
-		return ScrollPositions.BELOW;
-	}
-	if (boundingRect.top > 0) {
-		return ScrollPositions.ABOVE;
-	}
-	return ScrollPositions.FULL;
-};
-
 /**
  * An onScroll handler with throttling and scroll speed limiting.
  *

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,9 +1,3 @@
-export enum ScrollPositions {
-	FULL = 'FULL',
-	ABOVE = 'ABOVE',
-	BELOW = 'BELOW'
-}
-
 export type Style = {
 	/**
 	 * What styles to apply to panels.


### PR DESCRIPTION
This code was causing an issue whereby the Scrollyteller would load, but a race condition meant it was running before the dimensions were correct, so it was updating the marker and making the viz rerender with data from the wrong panel, before finally going back to the correct one.

This was visually glitchy, but also bad performance when rendering an intensive viz.

If we wait for the viz to be visible and rendered and ready before we display anything, we can remove the code that was causing the thrashing, and it just looks better.

I can't immediately think of why we shouldn't do this.