### PR TITLE
feat: loadScrollyteller accepts targetNode, fixes #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ const panels: PanelDefinition<MyPanelData>[] = [...];
 
 ## Props
 
-| Property        | Type                     | Description                                                                                                                            | Default            |
-| --------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| panels          | `PanelDefinition[]`      | **required** Array of nodes and data which dictate the markers                                                                         |
-| onMarker        | `(data: Data) => void`   | **required** Called when a marker intersects and returns that markers `data`                                                           |                    |
-| onProgress      | `(type, payload) => void`| Fires on scroll and returns the scrollyteller progress. payload is `{ boundingRect, rootPct, scrollPct }`                              |                    |
-| onLoad          | `(el: HTMLElement) => void`| Called when the interactive graphic mount node is ready.                                                                             |                    |
-| customPanel     | Svelte Component         | Component to replace the default panel component                                                                                       | Panel.svelte       |
-| observerOptions | IntersectionObserverInit | Options for the intersection observer. Refer to the [docs](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) | `{threshold: 0.5}` |
+| Property        | Type                        | Description                                                                                                                            | Default            |
+| --------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| panels          | `PanelDefinition[]`         | **required** Array of nodes and data which dictate the markers                                                                         |
+| onMarker        | `(data: Data) => void`      | **required** Called when a marker intersects and returns that markers `data`                                                           |                    |
+| onProgress      | `(type, payload) => void`   | Fires on scroll and returns the scrollyteller progress. payload is `{ boundingRect, rootPct, scrollPct }`                              |                    |
+| onLoad          | `(el: HTMLElement) => void` | Called when the interactive graphic mount node is ready.                                                                               |                    |
+| customPanel     | Svelte Component            | Component to replace the default panel component                                                                                       | Panel.svelte       |
+| observerOptions | IntersectionObserverInit    | Options for the intersection observer. Refer to the [docs](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) | `{threshold: 0.5}` |
 
 ## Using layouts/styling your own
 
@@ -182,6 +182,7 @@ JS Code:
 
 ```ts
 import { mount } from "svelte";
+import { selectMounts } from "@abcnews/mount-utils";
 import { loadScrollyteller } from "@abcnews/svelte-scrollyteller";
 import App from "App.svelte";
 
@@ -198,15 +199,21 @@ export type MyPanelData = {
   viz: "map" | "hex" | "chart";
 };
 
-const scrollyData = loadScrollyteller<MyPanelData>(
-  "", // If set to eg. "one" use #scrollytellerNAMEone in CoreMedia
-  "u-full", // Class to apply to mount node u-full makes it full width in Odyssey
-  "mark", // Name of marker in CoreMedia eg. for "point" use #point default: #mark
-);
+// Find all scrollyteller mount nodes
+const scrollyMounts = selectMounts("scrollytellerNAMEmyscrolly");
 
-mount(App, {
-  target: scrollyData.mountNode,
-  props: { panels: scrollyData.panels },
+scrollyMounts.forEach((mountNode) => {
+  // Initialise the scrollyteller using the target node directly
+  const scrollyData = loadScrollyteller<MyPanelData>(
+    mountNode,
+    "u-full", // Class to apply to mount node u-full makes it full width in Odyssey
+    "mark", // Name of marker in CoreMedia eg. for "point" use #point default: #mark
+  );
+
+  mount(App, {
+    target: scrollyData.mountNode,
+    props: { panels: scrollyData.panels },
+  });
 });
 ```
 

--- a/src/TestExample/ScrollyAppTest.svelte
+++ b/src/TestExample/ScrollyAppTest.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Scrollyteller, { loadScrollyteller } from "$lib/index.js";
+  import Scrollyteller, { loadScrollyteller } from "$lib/index";
   import PercentageIndicators from "./PercentageIndicators.svelte";
   import Worm from "./Worm/Worm.svelte";
   interface Props {
@@ -14,7 +14,7 @@
   const scrollyData = loadScrollyteller<MarkData>(
     name, // If set to eg. "one" use #scrollytellerNAMEone in CoreMedia
     "u-full", // Class to apply to mount point u-full makes it full width in Odyssey
-    "mark" // Name of marker in CoreMedia eg. for "point" use #point default: #mark
+    "mark", // Name of marker in CoreMedia eg. for "point" use #point default: #mark
   );
 
   let number = $state(0);
@@ -30,7 +30,7 @@
       boundingRect: DOMRect;
       rootPct: number;
       scrollPct: number;
-    }
+    },
   ) => {
     stProgress = payload;
   };

--- a/src/lib/Panel.svelte
+++ b/src/lib/Panel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getContext, onMount } from "svelte";
-  import { children } from "./actions.js";
-  import type { PanelRef } from "./types.js";
+  import { children } from "./actions";
+  import type { PanelRef } from "./types";
   import type { Writable } from "svelte/store";
 
   const currentPanel = getContext<Writable<number>>("currentPanel");

--- a/src/lib/Panels.svelte
+++ b/src/lib/Panels.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { ComponentType } from "svelte";
   import Panel from "./Panel.svelte";
-  import type { PanelDefinition, PanelRef, Style } from "./types.js";
+  import type { PanelDefinition, PanelRef, Style } from "./types";
 
   interface Props {
     panelRoot: HTMLElement;

--- a/src/lib/Scrollyteller.svelte
+++ b/src/lib/Scrollyteller.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" generics="Data = any">
   import type { ComponentType } from "svelte";
   import { onMount, setContext } from "svelte";
-  import type { PanelDefinition, Style } from "./types.js";
+  import type { PanelDefinition, Style } from "./types";
   import { getScrollSpeed } from "./Scrollyteller/Scrollyteller.util";
   import OnProgressHandler from "./Scrollyteller/OnProgressHandler.svelte";
   import PanelObserver from "./Scrollyteller/PanelObserver.svelte";
@@ -29,7 +29,7 @@
   const vizDimsStore = setContext("vizDims", setVizDims());
   const graphicRootDimsStore = setContext(
     "graphicRootDims",
-    setGraphicRootDims()
+    setGraphicRootDims(),
   );
   const ratioStore = setContext("ratio", setRatio());
   const screenDimsStore = setContext("screenDims", setScreenDims());
@@ -37,15 +37,15 @@
   const mobileVariantStore = setContext("mobileVariant", setMobileVariant());
   const isSplitScreenStore = setContext(
     "isSplitScreen",
-    setIsSplitScreen([screenDimsStore, globalAlignStore])
+    setIsSplitScreen([screenDimsStore, globalAlignStore]),
   );
   setContext(
     "isMobileRowMode",
-    setIsMobileRowMode([screenDimsStore, mobileVariantStore])
+    setIsMobileRowMode([screenDimsStore, mobileVariantStore]),
   );
   const maxScrollytellerWidthStore = setContext(
     "maxScrollytellerWidth",
-    setMaxScrollytellerWidth([isSplitScreenStore])
+    setMaxScrollytellerWidth([isSplitScreenStore]),
   );
   const maxGraphicWidthStore = setContext(
     "maxGraphicWidth",
@@ -55,7 +55,7 @@
       screenDimsStore,
       ratioStore,
       maxScrollytellerWidthStore,
-    ])
+    ]),
   );
   setContext("currentPanel", setCurrentPanel());
 
@@ -68,7 +68,7 @@
         boundingRect: DOMRect;
         rootPct: number;
         scrollPct: number;
-      }
+      },
     ) => void;
     onMarker?: (marker: Data) => void;
     onLoad?: (HTMLElement) => void;
@@ -104,7 +104,7 @@
         boundingRect: DOMRect;
         rootPct: number;
         scrollPct: number;
-      }
+      },
     ) => {},
     onMarker = (marker: Data) => {},
     onLoad = () => {},
@@ -130,7 +130,7 @@
     ([scrollytellerEntry]) =>
       deferUntilScrollSettles(() => {
         isInViewport = scrollytellerEntry.isIntersecting;
-      })
+      }),
   );
 
   const deferUntilScrollSettles = (fn) => {
@@ -191,7 +191,7 @@
   });
   // Debug mode should highlight blocks, graphic & show which breakpoint we're at
   let isDebug = $derived(
-    typeof location !== "undefined" && location.hash === "#debug=true"
+    typeof location !== "undefined" && location.hash === "#debug=true",
   );
 </script>
 
@@ -236,7 +236,7 @@
     class:scrollyteller--debug={isDebug}
     class:scrollyteller--columns={["left", "right"].includes(_layout.align)}
     class:scrollyteller--mobile-row-variant={["rows"].includes(
-      _layout.mobileVariant
+      _layout.mobileVariant,
     )}
     style:--maxScrollytellerWidthPx={$maxScrollytellerWidthStore + "px"}
     style:--rightColumnWidth={`min(calc(var(--maxScrollytellerWidth) * var(--vizMaxWidth)), ${$maxGraphicWidthStore}px)`}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,5 @@
 import Scrollyteller from "./Scrollyteller.svelte";
-export { loadScrollyteller } from "./utils.js";
+export { loadScrollyteller, getScrollytellerOpts } from "./utils";
+export type { ScrollytellerOptions } from "./utils";
 
 export default Scrollyteller;

--- a/src/lib/index.wc.ts
+++ b/src/lib/index.wc.ts
@@ -4,6 +4,7 @@
  * to plain Javascript so it can be consumed by non-Svelte projects.
  */
 import Scrollyteller from "./Scrollyteller.wc.svelte";
-export { loadScrollyteller } from "./utils.js";
+export { loadScrollyteller, getScrollytellerOpts } from "./utils";
+export type { ScrollytellerOptions } from "./utils";
 
 export default Scrollyteller;

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,5 +1,5 @@
 import { derived, writable } from "svelte/store";
-import { type PanelRef } from "./types.js";
+import { type PanelRef } from "./types";
 
 /** Each panel inserts itself into this list when it instantiates */
 export function setSteps() {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -39,7 +39,6 @@ export const loadScrollyteller = <Data = any>(
   className?: string,
   markerName = "mark",
 ): ScrollytellerDefinition<Data> => {
-  console.log("hi worlb");
   const hasTargetNode = nameOrNode && typeof nameOrNode !== "string";
   const targetNode = hasTargetNode ? (nameOrNode as Element) : null;
   const nameFromArgs = hasTargetNode ? "" : (nameOrNode as string);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import acto from "@abcnews/alternating-case-to-object";
 import { selectMounts, isMount, getMountValue } from "@abcnews/mount-utils";
-import type { PanelDefinition, ScrollytellerDefinition } from "./types.js";
+import type { PanelDefinition, ScrollytellerDefinition } from "./types";
 
 const piecemeal = Symbol("piecemeal");
 const SELECTOR_COMMON = "scrollyteller";
@@ -29,24 +29,31 @@ function excludePanelMeta(config: PanelMeta) {
 }
 
 /**
- * Finds and grabs any nodes between #scrollyteller and #endscrollyteller
- * @param name The hash name for a scrollyteller (optional if there is only one on the page)
- * @param className The className to apply to the mount node
- * @param markerName The hash name for markers
+ * Finds and grabs any nodes between #scrollyteller and #endscrollyteller.
+ * @param nameOrNode The unique identifier for the scrollyteller (string) or the target DOM element (Element).
+ * @param className The CSS class name to apply to the scrollyteller container element.
+ * @param markerName The prefix or name used to identify marking/anchor elements in the DOM.
  */
 export const loadScrollyteller = <Data = any>(
-  name?: string,
+  nameOrNode?: string | Element | null,
   className?: string,
   markerName = "mark",
 ): ScrollytellerDefinition<Data> => {
-  window.__scrollytellers = window.__scrollytellers || {};
+  console.log("hi worlb");
+  const hasTargetNode = nameOrNode && typeof nameOrNode !== "string";
+  const targetNode = hasTargetNode ? (nameOrNode as Element) : null;
+  const nameFromArgs = hasTargetNode ? "" : (nameOrNode as string);
 
+  // name is optional when using targetNode, but we still need a cache key
+  const name =
+    nameFromArgs || targetNode?.getAttribute("id") || "scrollyteller";
+
+  window.__scrollytellers = window.__scrollytellers || {};
   const openingMountValuePrefix = `${SELECTOR_COMMON}${name ? `NAME${name}` : ""}`;
 
-  name = name || "scrollyteller";
-
   if (!window.__scrollytellers[name]) {
-    const firstEl: Element | null = selectMounts(openingMountValuePrefix)[0];
+    const firstEl: Element | null =
+      targetNode || selectMounts(openingMountValuePrefix)[0];
 
     if (!firstEl) {
       throw new Error(`Couldn't find element for #${openingMountValuePrefix}`);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -39,9 +39,8 @@ export const loadScrollyteller = <Data = any>(
   className?: string,
   markerName = "mark",
 ): ScrollytellerDefinition<Data> => {
-  const hasTargetNode = nameOrNode && typeof nameOrNode !== "string";
-  const targetNode = hasTargetNode ? (nameOrNode as Element) : null;
-  const nameFromArgs = hasTargetNode ? "" : (nameOrNode as string);
+  const targetNode = typeof nameOrNode !== "string" ? nameOrNode : null;
+  const nameFromArgs = typeof nameOrNode === "string" ? nameOrNode : "";
 
   // name is optional when using targetNode, but we still need a cache key
   const name =

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -35,7 +35,7 @@ function excludePanelMeta(config: PanelMeta) {
  * @param markerName The prefix or name used to identify #mark elements in the DOM.
  */
 export const loadScrollyteller = <Data = any>(
-  nameOrNode?: string | Element | null,
+  nameOrNode?: string | Element | undefined,
   className?: string,
   markerName = "mark",
 ): ScrollytellerDefinition<Data> => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -32,7 +32,7 @@ function excludePanelMeta(config: PanelMeta) {
  * Finds and grabs any nodes between #scrollyteller and #endscrollyteller.
  * @param nameOrNode The unique identifier for the scrollyteller (string) or the target DOM element (Element).
  * @param className The CSS class name to apply to the scrollyteller container element.
- * @param markerName The prefix or name used to identify marking/anchor elements in the DOM.
+ * @param markerName The prefix or name used to identify #mark elements in the DOM.
  */
 export const loadScrollyteller = <Data = any>(
   nameOrNode?: string | Element | null,


### PR DESCRIPTION
1. overload the first argument of `loadScrollyteller` to also accept a `targetNode`. This bypasses the existing `selectMounts` logic
2. remove .ts and .js from imports because it's nonstandard and makes it harder to test

I've wanted to do this for a while, because it lets us implement multiple scrollytellers in the page much easier:

<img width="525" height="139" alt="image" src="https://github.com/user-attachments/assets/9c7dd3df-bf94-454d-b8e8-e7bed6774ab1" />

Previously we needed to add their own unique names to each opening marker, increment the numbers in the name prop for each scrolly, then pass the unique names into `loadScrollyteller`. With this change we can select all the scrollyteller mounts and pass them straight to loadScrollyteller, it's much tidier.

This is not a breaking change, so we can make it a minor release.