### PR TITLE
bug: panels appear in weird positions in left/right mode

### DIFF
--- a/src/lib/Panel.svelte
+++ b/src/lib/Panel.svelte
@@ -24,8 +24,6 @@
     currentPanel = 0,
     panelRef = $bindable(),
   }: Props = $props();
-
-
 </script>
 
 <div
@@ -91,7 +89,9 @@
     }
 
     &.first {
-      margin-top: 100dvh;
+      // First panel appears 80% down the screen for mobile/centre aligned.
+      // Overridden to 50% for left/right aligned
+      margin-top: 80dvh;
     }
 
     &.last {
@@ -116,6 +116,7 @@
           opacity: var(--panel-opacity-inactive);
         }
         &.first {
+          // First panel appears 50% down the screen, overriding the default 80%
           margin-top: 50dvh;
         }
       }

--- a/src/lib/Scrollyteller.stories.svelte
+++ b/src/lib/Scrollyteller.stories.svelte
@@ -189,7 +189,6 @@
         ].text}; --worm: {markerStates[activeIndex].text};"
       >
         <Worm />
-        <span class="number">{activeIndex + 1}</span>
 
         <!-- Scrollbar and progress indicator HUD -->
         <div
@@ -214,7 +213,7 @@
             class="progress-text"
             style="color: {markerStates[activeIndex].text};"
           >
-            Scroll progress: {Math.round(scrollProgress * 100)}%
+            Panel {activeIndex + 1} · Scroll progress: {Math.round(scrollProgress * 100)}%
           </p>
         </div>
       </div>
@@ -313,18 +312,6 @@
     box-shadow: inset 0 0 50px rgba(0, 0, 0, 0.15);
     box-sizing: border-box;
     padding: 2rem;
-  }
-
-  .number {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    font-family: ABCSans, sans-serif;
-    font-weight: 900;
-    font-size: 3.5rem;
-    color: inherit;
-    z-index: 2;
   }
 
   .progress-hud {

--- a/src/lib/Scrollyteller/usePanelObserver.svelte.ts
+++ b/src/lib/Scrollyteller/usePanelObserver.svelte.ts
@@ -82,7 +82,12 @@ export function usePanelObserver(props: PanelObserverProps) {
   let intersectingPanels = $state<IntersectionEntries[]>([]);
 
   $effect(() => {
-    if (props.vizDims.status !== "ready" || !props.steps.length) {
+    // Depend on screen dims so the observer reloads on change.
+    // Specifically fixes issues in Storybook
+    const [, screenHeight] = props.screenDims;
+    const vizDims = props.vizDims;
+
+    if (vizDims.status !== "ready" || !props.steps.length || !screenHeight) {
       return;
     }
     intersectingPanels = [];

--- a/src/lib/Viz.svelte
+++ b/src/lib/Viz.svelte
@@ -116,7 +116,7 @@
     position: sticky;
     top: 0;
     left: 0;
-    height: 100dvh;
+    
     z-index: 1;
   }
 

--- a/src/lib/Viz.svelte
+++ b/src/lib/Viz.svelte
@@ -109,8 +109,9 @@
     }
   }
 
-  // Reserve 100dvh screen height, regardless of how big the viz is
-  .viz {
+  // Panel positioning is dependent on this block being 100dvh, even if the
+  // actual interactive is smaller.
+  .viz-flow {
     height: 100dvh;
     position: sticky;
     top: 0;

--- a/src/lib/Viz.svelte
+++ b/src/lib/Viz.svelte
@@ -31,8 +31,6 @@
     }
   });
 
-
-
   $effect(() => {
     if (!graphicRootEl) return;
 
@@ -73,17 +71,19 @@
   });
 </script>
 
-<div
-  class="viz"
-  class:viz--resized={layout.resizeInteractive}
-  class:viz--right={layout.resizeInteractive && layout.align === "left"}
-  class:viz--left={layout.resizeInteractive && layout.align === "right"}
-  class:viz--centre={layout.resizeInteractive && layout.align === "centre"}
-  bind:this={graphicRootEl}
->
-  {#if isInViewport || discardSlot === false}
-    {@render children?.()}
-  {/if}
+<div class="viz-flow">
+  <div
+    class="viz"
+    class:viz--resized={layout.resizeInteractive}
+    class:viz--right={layout.resizeInteractive && layout.align === "left"}
+    class:viz--left={layout.resizeInteractive && layout.align === "right"}
+    class:viz--centre={layout.resizeInteractive && layout.align === "centre"}
+    bind:this={graphicRootEl}
+  >
+    {#if isInViewport || discardSlot === false}
+      {@render children?.()}
+    {/if}
+  </div>
 </div>
 
 <style lang="scss">
@@ -109,13 +109,21 @@
     }
   }
 
+  // Reserve 100dvh screen height, regardless of how big the viz is
   .viz {
-    transform: translate3d(0, 0, 0);
     height: 100dvh;
     position: sticky;
     top: 0;
     left: 0;
+    height: 100dvh;
     z-index: 1;
+  }
+
+  .viz {
+    // The actual viz size, this can change size based on resizeInteractive
+    position: absolute;
+    inset: 0;
+    transform: translate3d(0, 0, 0);
   }
 
   .viz--resized {


### PR DESCRIPTION
Hit the Storybook bug, then realised we had a few different bugs in there:

* bug: panels in left/right mode expected viz to be 100dvh high, but it was actually scaled to the `resizeInteractive` ratio
* bug: panels in centre mode started at 100dvh which pushed them off the screen - changed to 80 by default
* bug: Storybook/small screens in left/right mode would inadvertently start at the second panel if it was visible

solutions:
1. reregister the intersection obesrver when the scrolly size changes
2. make sure the viz is always 100dvh high to keep the calculations consistent, even when we're resizing the inner contents
3. Make the default first panel 80dvh (or 50dvh for left/right mode) so it peeks out the bottom. I think this is configurable in the props, but this should be a good default.